### PR TITLE
Send an OSC message when the OSC interface starts or stops

### DIFF
--- a/mididings/extra/osc.py
+++ b/mididings/extra/osc.py
@@ -56,10 +56,12 @@ class OSCInterface(object):
             self.server.register_methods(self)
             self.server.start()
 
-        self.send_config()
+        self.send_config(True)
 
     def on_exit(self):
         if self.port is not None:
+            for p in self.notify_ports:
+                _liblo.send(p, '/mididings/exit')
             self.server.stop()
             del self.server
 
@@ -67,8 +69,9 @@ class OSCInterface(object):
         for p in self.notify_ports:
             _liblo.send(p, '/mididings/current_scene', scene, subscene)
 
-    def send_config(self):
+    def send_config(self, start=False):
         for p in self.notify_ports:
+            if start: _liblo.send(p, '/mididings/start')
             # send data offset
             _liblo.send(p, '/mididings/data_offset',
                         _setup.get_config('data_offset'))

--- a/mididings/live/livedings.py
+++ b/mididings/live/livedings.py
@@ -197,6 +197,12 @@ class LiveDings(object):
         self.listbox.selection_set(sorted(self.scenes.keys()).index(scene))
         self.update()
 
+    def on_exit(self):
+        pass
+
+    def on_start(self):
+        pass
+
     def update_scenes(self):
         self.listbox.delete(0, 'end')
         for n in sorted(self.scenes.keys()):

--- a/mididings/live/osc_control.py
+++ b/mididings/live/osc_control.py
@@ -67,3 +67,11 @@ class LiveOSC(liblo.ServerThread):
     @liblo.make_method('/mididings/current_scene', 'ii')
     def current_scene_cb(self, path, args):
         self.dings.set_current_scene(args[0], args[1])
+
+    @liblo.make_method('/mididings/exit', '')
+    def on_exit_cb(self, path, args):
+        self.dings.on_exit()
+
+    @liblo.make_method('/mididings/start', '')
+    def on_start_cb(self, path, args):
+        self.dings.on_start()


### PR DESCRIPTION
To address issue  #5
* OSC clients will be notified when the OSC interface (and mididings as well) starts or stops.
* No presentation logic implemented in the livedings UI callback
