### PR TITLE
Allow call of the /quit and /restart OSC messages in LiveOSC class

### DIFF
--- a/mididings/extra/osc.py
+++ b/mididings/extra/osc.py
@@ -42,6 +42,7 @@ class OSCInterface(object):
     - **/mididings/panic**: send all-notes-off on all channels and on all
       output ports.
     - **/mididings/quit**: terminate mididings.
+    - **/mididings/restart**: restart mididings.
     """
     def __init__(self, port=56418, notify_ports=[56419]):
         self.port = port

--- a/mididings/live/osc_control.py
+++ b/mididings/live/osc_control.py
@@ -46,6 +46,12 @@ class LiveOSC(liblo.ServerThread):
     def panic(self):
         self.send(self.control_port, '/mididings/panic')
 
+    def quit(self):
+        self.send(self.control_port, '/mididings/quit')
+
+    def restart(self):
+        self.send(self.control_port, '/mididings/restart')
+
     @liblo.make_method('/mididings/data_offset', 'i')
     def data_offset_cb(self, path, args):
         self.dings.set_data_offset(args[0])


### PR DESCRIPTION
To address issue #7

* An OSC client will be able to restart or quit mididings using the LiveOSC class. This was only possible by creating a child class of LiveOSC and implementing the two methods.
* LiveOSC class now support 100% of the OSCInterface.