### PR TITLE
event: mask boost-python safety-guard (false positive)

### DIFF
--- a/mididings/event.py
+++ b/mididings/event.py
@@ -66,6 +66,10 @@ class MidiEvent(_mididings.MidiEvent):
         if sysex is not None:
             self.sysex_ = sysex
 
+    # mask boost python safety-guard, as we don't use __getstate__, but __getinitargs__
+    # more info: https://beta.boost.org/doc/libs/1_53_0/libs/python/doc/v2/pickle.html
+    __getstate_manages_dict__ = 1
+
     def __getinitargs__(self):
         self._finalize()
         return (self.type, self.port, self.channel, self.data1, self.data2,


### PR DESCRIPTION
This addresses issue #12 

The error arises because of a safety-guard in boost-python concerning pickling.
More info: https://beta.boost.org/doc/libs/1_53_0/libs/python/doc/v2/pickle.html

Background: `mididings.MidiEvent` uses `__getinitargs__()` for pickling. The above documentation states potential problems when using `__getstate__()`/`__setstate__()` and mentions `__getinitargs__()` as a safe alternative, which we already use.

As far as I can tell the issue arises only in pytest where `__getstate__()` is defined for the `MidiEvent` object, so the safety-guard triggers (which it actually shouldn't because `__dict__` is empty, but it still does). So in summary: we already to the right thing (pickling with `__getinitargs__()` and the safety-guard fails to check all necessary conditions, so a false positive is triggered under test conditions.

As to why this only happens on python 3.11 or newer, I have no idea.