### PR TITLE
Implement GitHub CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ "primary" ]
+    branches: [ "primary", "github-ci" ]
   pull_request:
     branches: [ "primary" ]
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,12 +12,12 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-22.04]
     strategy:
       fail-fast: false
       matrix:
+        os: ["ubuntu-22.04", "ubuntu-24.04"]
         python-version: ["3.9", "3.10", "3.11"]
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "primary" ]
+  pull_request:
+    branches: [ "primary" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install System dependencies
+      run: |
+        python -m pip install yq
+        tomlq '."ubuntu-22-04"."pkgs"[]' pkglist.toml | xargs sudo apt-get install
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest meson-python
+    - name: Build and Install
+      run: |
+        python -m pip install .
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,6 +18,10 @@ jobs:
       matrix:
         os: ["ubuntu-22.04", "ubuntu-24.04"]
         python-version: ["3.9", "3.10", "3.11"]
+        exclude:
+          # ubuntu-22.04 and python 3.11 don't work for mididings
+          - os: "ubuntu-22.04"
+            python-version: "3.11"
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: [ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -27,7 +27,7 @@ jobs:
     - name: Install System dependencies
       run: |
         python -m pip install yq
-        tomlq '."ubuntu-22-04"."pkgs"[]' pkglist.toml | xargs sudo apt-get install
+        tomlq '."${{ matrix.os }}"."pkgs"[]' pkglist.toml | xargs sudo apt-get install
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pkglist.toml
+++ b/pkglist.toml
@@ -1,4 +1,7 @@
-[ubuntu-22-04]
+['ubuntu-22.04']
+pkgs = ["build-essential", "meson", "ninja-build", "python3-venv", "git", "pip", "libboost-dev", "libboost-python-dev", "libboost-thread-dev", "libasound2-dev", "libjack-dev"]
+
+['ubuntu-24.04']
 pkgs = ["build-essential", "meson", "ninja-build", "python3-venv", "git", "pip", "libboost-dev", "libboost-python-dev", "libboost-thread-dev", "libasound2-dev", "libjack-dev"]
 
 [fedora]

--- a/pkglist.toml
+++ b/pkglist.toml
@@ -1,11 +1,11 @@
 [ubuntu-22-04]
-pkgs = ["python3-venv", "git", "pip", "libboost-dev", "libboost-python-dev", "libasound2-dev", "libjack-dev"]
+pkgs = ["build-essential", "meson", "ninja-build", "python3-venv", "git", "pip", "libboost-dev", "libboost-python-dev", "libboost-thread-dev", "libasound2-dev", "libjack-dev"]
 
 [fedora]
-pkgs = ["python3-pip", "boost-devel", "boost-python-devel", "gcc", "python3-devel", "alsa-lib-devel"]
+pkgs = ["meson", "ninja", "python3-pip", "boost-devel", "boost-python-devel", "gcc", "python3-devel", "alsa-lib-devel"]
 
 [mint-21]
-pkgs = ["build-essential", "git", "python3-venv", "libboost-dev", "libboost-python-dev", "libasound2-dev", "libjack-dev"]
+pkgs = ["build-essential", "meson", "ninja-build", "git", "python3-venv", "libboost-dev", "libboost-python-dev", "libasound2-dev", "libjack-dev"]
 
 [arch]
-pkgs = ["base-devel", "git", "python-pip", "python-virtualenv", "boost", "alsa-lib", "jack2"]
+pkgs = ["base-devel", "meson", "ninja", "git", "python-pip", "python-virtualenv", "boost", "alsa-lib", "jack2"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -21,7 +21,7 @@ class TestVersion:
         mididings_version = None
 
         meson_ver = re.compile(r".*version *: *'([^']*)'")
-        doc_ver = re.compile(r"version = \"(.*)\"")
+        doc_ver = re.compile(r"version = (.*)")
         pyproject_dyn_ver = re.compile(r"(dynamic) *= *\[.*'version'.*\]")
 
         version = open_and_extract("meson.build", meson_ver, "project")
@@ -30,9 +30,8 @@ class TestVersion:
         pyproject_version = open_and_extract("pyproject.toml", pyproject_dyn_ver, "dynamic")
 
         assert version is not None
-        assert documentation_version is not None
         assert mididings_version is not None
-        assert version == documentation_version
         assert version == mididings_version
+        assert documentation_version == "mesonconf.version"
         assert pyproject_version == "dynamic"
 


### PR DESCRIPTION
Implement a github runner to build and test mididings under a few combinations of versions of Ubuntu and Python.
The failing test on Ubuntu 24.04 and python 3.11 is addressed by #17 
Ubuntu 22.04 and python 3.11 have different more severe issues and since mididings works with python 3.11 under Ubuntu 24.04 and Ubuntu 22.04 has other working python versions we can just mask this combination in my opinion.